### PR TITLE
emit console error if `DANGER_GITHUB_API_TOKEN` is not set.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 //  Add your own contribution below
 
+### 0.6.4
+
+* Warning if DANGER_GITHUB_API_TOKEN env var is not set
+
 ### 0.6.3
 
 * Does not break commonmark on GitHub - orta

--- a/source/platforms/platform.js
+++ b/source/platforms/platform.js
@@ -69,7 +69,12 @@ import { GitHub } from "./GitHub"
  * @returns {?Platform} returns a platform if it can be supported
 */
 export function getPlatformForEnv(env: Env, source: CISource): ?Platform {
-  const github = new GitHub(env["DANGER_GITHUB_API_TOKEN"], source)
+  const token = env["DANGER_GITHUB_API_TOKEN"]
+  if (!token) {
+    console.error("The DANGER_GITHUB_API_TOKEN environmental variable is missing")
+    console.error("Without an api token, danger will be unable to comment on a PR")
+  }
+  const github = new GitHub(token, source)
   return github
 }
 


### PR DESCRIPTION
Without this, danger will appear to fail because it is unable to
execute `.find()` within the PR's comments